### PR TITLE
bitPUSHER upgrade for bitcash

### DIFF
--- a/bitcash/__init__.py
+++ b/bitcash/__init__.py
@@ -2,5 +2,6 @@ from bitcash.format import verify_sig
 from bitcash.network.rates import SUPPORTED_CURRENCIES, set_rate_cache_time
 from bitcash.network.services import set_service_timeout
 from bitcash.wallet import Key, PrivateKey, PrivateKeyTestnet, wif_to_key
+from bitcash.bitpusher import create_PUSHDATA
 
 __version__ = '0.5.2'

--- a/bitcash/bitpusher.py
+++ b/bitcash/bitpusher.py
@@ -4,7 +4,8 @@ def create_PUSHDATA(lst_of_PUSHDATA):
     '''
     Takes in a list of (PUSHDATA, encoding type) tuples
     Returns binary encoded OP_RETURN PUSHDATA (automatically adds intervening OP_CODES specifying number of bytes in each PUSHDATA element)
-    0x6a (i.e. OP_RETURN) is added in other, auxillary functions, only PUSHDATA is returned
+    0x6a (i.e. OP_RETURN) is added in other, auxillary functions; only PUSHDATA is returned.
+    Max 220 bytes of PUSHDATA
     
     Example:
     
@@ -49,7 +50,6 @@ def create_PUSHDATA(lst_of_PUSHDATA):
             
         encoding = lst_of_PUSHDATA[i][1]
         if encoding == 'utf-8':
-            #FIXME - currently only handles up to 256 bytes per input
             PUSHDATA += len(lst_of_PUSHDATA[i][0]).to_bytes(1, byteorder='little') + lst_of_PUSHDATA[i][0].encode('utf-8')
         
         elif encoding == 'hex' and len(lst_of_PUSHDATA[i][0]) % 2 != 0:

--- a/bitcash/bitpusher.py
+++ b/bitcash/bitpusher.py
@@ -1,0 +1,68 @@
+import bitcash
+import cashaddress
+import requests
+
+def create_PUSHDATA(lst_of_PUSHDATA):
+    '''
+    Takes in a list of (PUSHDATA, encoding type) tuples
+    Returns binary encoded OP_RETURN PUSHDATA (automatically adds intervening OP_CODES specifying number of bytes in each PUSHDATA element)
+    0x6a (i.e. OP_RETURN) is added in other, auxillary functions, only PUSHDATA is returned
+    
+    Example:
+    
+        lst_of_PUSHDATA =  [('6d01', 'hex'), 
+                            ('bitPUSHER', 'utf-8')]
+                            
+        as per memo.cash protocol @ https://memo.cash/protocol
+        This will result in a "Set name" action to "bitPUSHER"
+        
+        raw OP_RETURN will be:
+        
+            0e 6a 02 6d01 09 626974505553484552 
+            
+                0e                  - 14 bytes to follow (in hex)
+                6a                  - OP_RETURN
+                02                  - 2 bytes of PUSHDATA to follow
+                6d01                - "communication channel" for memo.cash - "set name" action
+                09                  - 9 bytes to follow
+                626974505553484552  - "bitPUSHER" utf-8 encoded bytes --> hex representation
+                
+        Currently (this module) only allows up to 220 bytes maximum at present. 
+        Will soon increase this capability dramatically by allowing for overflow.
+        
+        RECOMMENDED WORKFLOW
+        # Import private key with bitcash
+            my_key = bitcash.PrivateKey('WIF Compressed (base58) here')
+            my_key.get_unspents() #necessary step --> updates my_key.unspents object variable
+        
+        # Output OP_RETURN PUSHDATA as bytes and store in variable
+            PUSHDATA_variable = bitPUSHER(lst_of_PUSHDATA) --> outputs OP_RETURN PUSHDATA as bytes and stores in variable
+        
+        # Create rawtx ready for broadcast (fee = 1 sat/byte; sending 0.0001 BCH back to own address)
+            rawtx = my_key.create_transaction([(my_key.address, 0.0001, 'bch')], fee=1, message=PUSHDATA, custom_PUSHDATA=True)
+        
+        # Broadcast rawtx
+            bitcash.network.services.NetworkAPI.broadcast_tx(rawtx)
+            --> look at block explorer or wallet to see new transaction! 
+    '''
+    PUSHDATA = b''
+    
+    for i in range(len(lst_of_PUSHDATA)):
+            
+        encoding = lst_of_PUSHDATA[i][1]
+        if encoding == 'utf-8':
+            #FIXME - currently only handles up to 256 bytes per input
+            PUSHDATA += len(lst_of_PUSHDATA[i][0]).to_bytes(1, byteorder='little') + lst_of_PUSHDATA[i][0].encode('utf-8')
+        
+        elif encoding == 'hex' and len(lst_of_PUSHDATA[i][0]) % 2 != 0:
+            raise ValueError("hex encoded PUSHDATA must have length = a multiple of two")
+            
+        elif encoding == 'hex' and len(lst_of_PUSHDATA[i][0]) % 2 == 0:
+            PUSHDATA += (len(lst_of_PUSHDATA[i][0])//2).to_bytes(1, byteorder='little') + bitcash.utils.hex_to_bytes(lst_of_PUSHDATA[i][0])
+        
+    #check for size
+    if len(PUSHDATA) > 220:
+        raise ValueError("Total bytes in OP_RETURN cannot exceed 220 bytes at present - apologies")
+        
+    return PUSHDATA
+

--- a/bitcash/bitpusher.py
+++ b/bitcash/bitpusher.py
@@ -1,6 +1,4 @@
 import bitcash
-import cashaddress
-import requests
 
 def create_PUSHDATA(lst_of_PUSHDATA):
     '''
@@ -36,10 +34,10 @@ def create_PUSHDATA(lst_of_PUSHDATA):
             my_key.get_unspents() #necessary step --> updates my_key.unspents object variable
         
         # Output OP_RETURN PUSHDATA as bytes and store in variable
-            PUSHDATA_variable = bitPUSHER(lst_of_PUSHDATA) --> outputs OP_RETURN PUSHDATA as bytes and stores in variable
+            pushdata = bitPUSHER.create_PUSHDATA(lst_of_PUSHDATA) --> outputs OP_RETURN PUSHDATA as bytes and stores in variable
         
         # Create rawtx ready for broadcast (fee = 1 sat/byte; sending 0.0001 BCH back to own address)
-            rawtx = my_key.create_transaction([(my_key.address, 0.0001, 'bch')], fee=1, message=PUSHDATA, custom_PUSHDATA=True)
+            rawtx = my_key.create_transaction([(my_key.address, 0.0001, 'bch')], fee=1, message=pushdata, custom_PUSHDATA=True)
         
         # Broadcast rawtx
             bitcash.network.services.NetworkAPI.broadcast_tx(rawtx)

--- a/bitcash/network/fees.py
+++ b/bitcash/network/fees.py
@@ -6,9 +6,9 @@
 # Medium should get in within the next couple blocks, 90% certainty.
 # Slow, in a few hours, 90% certainty.
 # The default should be medium so you can go up/down from there.
-DEFAULT_FEE_FAST = 8
-DEFAULT_FEE_MEDIUM = 4
-DEFAULT_FEE_SLOW = 2
+DEFAULT_FEE_FAST = 3
+DEFAULT_FEE_MEDIUM = 2
+DEFAULT_FEE_SLOW = 1
 
 # FIXME: Need to add in a fees API. Issue #1
 # URL = 'https://bitcoincashfees.earn.com/api/v1/fees/recommended'

--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -196,6 +196,7 @@ class NetworkAPI:
     @classmethod
     def get_balance(cls, address):
         """Gets the balance of an address in satoshi.
+
         :param address: The address in question.
         :type address: ``str``
         :raises ConnectionError: If all API services fail.
@@ -213,6 +214,7 @@ class NetworkAPI:
     @classmethod
     def get_balance_testnet(cls, address):
         """Gets the balance of an address on the test network in satoshi.
+
         :param address: The address in question.
         :type address: ``str``
         :raises ConnectionError: If all API services fail.
@@ -230,6 +232,7 @@ class NetworkAPI:
     @classmethod
     def get_transactions(cls, address):
         """Gets the ID of all transactions related to an address.
+
         :param address: The address in question.
         :type address: ``str``
         :raises ConnectionError: If all API services fail.
@@ -248,6 +251,7 @@ class NetworkAPI:
     def get_transactions_testnet(cls, address):
         """Gets the ID of all transactions related to an address on the test
         network.
+
         :param address: The address in question.
         :type address: ``str``
         :raises ConnectionError: If all API services fail.
@@ -265,6 +269,7 @@ class NetworkAPI:
     @classmethod
     def get_tx_amount(cls, txid, txindex):
         """Gets the ID of all transactions related to an address.
+
         :param txid: The transaction id in question.
         :type txid: ``str``
         :param txindex: The transaction index in question.
@@ -284,6 +289,7 @@ class NetworkAPI:
     @classmethod
     def get_unspent(cls, address):
         """Gets all unspent transaction outputs belonging to an address.
+
         :param address: The address in question.
         :type address: ``str``
         :raises ConnectionError: If all API services fail.
@@ -302,6 +308,7 @@ class NetworkAPI:
     def get_unspent_testnet(cls, address):
         """Gets all unspent transaction outputs belonging to an address on the
         test network.
+
         :param address: The address in question.
         :type address: ``str``
         :raises ConnectionError: If all API services fail.
@@ -319,6 +326,7 @@ class NetworkAPI:
     @classmethod
     def broadcast_tx(cls, tx_hex):  # pragma: no cover
         """Broadcasts a transaction to the blockchain.
+
         :param tx_hex: A signed transaction in hex form.
         :type tx_hex: ``str``
         :raises ConnectionError: If all API services fail.
@@ -343,6 +351,7 @@ class NetworkAPI:
     @classmethod
     def broadcast_tx_testnet(cls, tx_hex):  # pragma: no cover
         """Broadcasts a transaction to the test network's blockchain.
+
         :param tx_hex: A signed transaction in hex form.
         :type tx_hex: ``str``
         :raises ConnectionError: If all API services fail.

--- a/bitcash/transaction.py
+++ b/bitcash/transaction.py
@@ -33,7 +33,7 @@ OP_HASH160 = b'\xa9'
 OP_PUSH_20 = b'\x14'
 OP_RETURN = b'\x6a'
 
-MESSAGE_LIMIT = 40
+MESSAGE_LIMIT = 220
 
 
 class TxIn:
@@ -90,7 +90,7 @@ def estimate_tx_fee(n_in, n_out, satoshis, compressed):
     return estimated_fee
 
 
-def sanitize_tx_data(unspents, outputs, fee, leftover, combine=True, message=None, compressed=True):
+def sanitize_tx_data(unspents, outputs, fee, leftover, combine=True, message=None, compressed=True, custom_PUSHDATA=False):
     """
     sanitize_tx_data()
 
@@ -104,19 +104,27 @@ def sanitize_tx_data(unspents, outputs, fee, leftover, combine=True, message=Non
         # LEGACYADDRESSDEPRECATION
         # FIXME: Will be removed in an upcoming release, breaking compatibility with legacy addresses.
         dest = cashaddress.to_cash_address(dest)
-        outputs[i] = (dest, currency_to_satoshi_cached(amount, currency))
+        outputs[i] = (dest, currency_to_satoshi_cached(amount, currency)) #condenses 'output' from tuple of 3 elements --> tuple of two elements (destination address, satoshis)
 
     if not unspents:
         raise ValueError('Transactions must have at least one unspent.')
 
     # Temporary storage so all outputs precede messages.
     messages = []
-
-    if message:
+    
+    # Status quo for sending utf-8 encoded messages in OP_RETURN
+    if ((len(message) > 0) and (custom_PUSHDATA == False)):
         message_chunks = chunk_data(message.encode('utf-8'), MESSAGE_LIMIT)
 
         for message in message_chunks:
-            messages.append((message, 0))
+            messages.append((message, 0)) #dest, amount
+            
+    # Custom PUSHDATA in OP_RETURN  
+        # Takes in message as raw PUSHDATA (must be already encoded as bytes - hex or utf-8)
+        # The (dest, amount) tuple in output list is (PUSHDATA, 0) in this case. 
+        # Max size of 220 bytes at this stage
+    elif (message and custom_PUSHDATA ==True):
+        messages.append((message, 0))
 
     # Include return address in fee estimate.
 
@@ -159,8 +167,10 @@ def sanitize_tx_data(unspents, outputs, fee, leftover, combine=True, message=Non
     return unspents, outputs
 
 
-def construct_output_block(outputs):
-
+def construct_output_block(outputs, custom_PUSHDATA=False):
+    #If Custom_PUSHDATA == False (Default), and amount = 0. 'the (0-220 byte long) string in place of destination address is treated as one utf-8 encoded message. 
+    #If Custom_PUSHDATA == True, raw hex will be directly appended after OP_RETURN.
+    
     output_block = b''
 
     for data in outputs:
@@ -176,15 +186,21 @@ def construct_output_block(outputs):
 
         # Blockchain storage
         else:
-            script = (OP_RETURN +
-                      len(dest).to_bytes(1, byteorder='little') +
-                      dest)
-
-            output_block += b'\x00\x00\x00\x00\x00\x00\x00\x00'
+            if (custom_PUSHDATA == False):
+                script = (OP_RETURN +
+                            len(dest).to_bytes(1, byteorder='little') +
+                            dest)
+                            
+                output_block += b'\x00\x00\x00\x00\x00\x00\x00\x00'
+            
+            elif (custom_PUSHDATA == True):
+                script = (OP_RETURN + dest) #Note: you must manually enter "len(PUSHDATA_element).to_bytes(1, byteorder='little')" before every PUSHDATA_element before executing this function
+                
+                output_block += b'\x00\x00\x00\x00\x00\x00\x00\x00'
 
         output_block += int_to_unknown_bytes(len(script), byteorder='little')
         output_block += script
-
+			
     return output_block
 
 
@@ -205,8 +221,8 @@ def construct_input_block(inputs):
     return input_block
 
 
-def create_p2pkh_transaction(private_key, unspents, outputs):
-
+def create_p2pkh_transaction(private_key, unspents, outputs, custom_PUSHDATA=False):
+    
     public_key = private_key.public_key
     public_key_len = len(public_key).to_bytes(1, byteorder='little')
 
@@ -219,8 +235,13 @@ def create_p2pkh_transaction(private_key, unspents, outputs):
     hash_type = HASH_TYPE
     input_count = int_to_unknown_bytes(len(unspents), byteorder='little')
     output_count = int_to_unknown_bytes(len(outputs), byteorder='little')
-    output_block = construct_output_block(outputs)
+    
+    if (custom_PUSHDATA == False):
+        output_block = construct_output_block(outputs)
+    else:
+        output_block = construct_output_block(outputs, custom_PUSHDATA=True)
 
+            
     # Optimize for speed, not memory, by pre-computing values.
     inputs = []
     for unspent in unspents:

--- a/bitcash/wallet.py
+++ b/bitcash/wallet.py
@@ -206,7 +206,7 @@ class PrivateKey(BaseKey):
         return self.transactions
 
     def create_transaction(self, outputs, fee=None, leftover=None, combine=True,
-                           message=None, unspents=None):  # pragma: no cover
+                           message=None, unspents=None, custom_PUSHDATA=False):  # pragma: no cover
         """Creates a signed P2PKH transaction.
 
         :param outputs: A sequence of outputs you wish to send in the form
@@ -238,7 +238,7 @@ class PrivateKey(BaseKey):
         :returns: The signed transaction as hex.
         :rtype: ``str``
         """
-
+        print('create:', custom_PUSHDATA)
         unspents, outputs = sanitize_tx_data(
             unspents or self.unspents,
             outputs,
@@ -246,10 +246,11 @@ class PrivateKey(BaseKey):
             leftover or self.address,
             combine=combine,
             message=message,
-            compressed=self.is_compressed()
+            compressed=self.is_compressed(),
+            custom_PUSHDATA=custom_PUSHDATA
         )
 
-        return create_p2pkh_transaction(self, unspents, outputs)
+        return create_p2pkh_transaction(self, unspents, outputs, custom_PUSHDATA=custom_PUSHDATA)
 
     def send(self, outputs, fee=None, leftover=None, combine=True,
              message=None, unspents=None):  # pragma: no cover
@@ -278,7 +279,7 @@ class PrivateKey(BaseKey):
         :type combine: ``bool``
         :param message: A message to include in the transaction. This will be
                         stored in the blockchain forever. Due to size limits,
-                        each message will be stored in chunks of 40 bytes.
+                        each message will be stored in chunks of 220 bytes.
         :type message: ``str``
         :param unspents: The UTXOs to use as the inputs. By default Bitcash will
                          communicate with the blockchain itself.
@@ -499,7 +500,7 @@ class PrivateKeyTestnet(BaseKey):
         return self.transactions
 
     def create_transaction(self, outputs, fee=None, leftover=None, combine=True,
-                           message=None, unspents=None):
+                           message=None, unspents=None, custom_PUSHDATA=False):
         """Creates a signed P2PKH transaction.
 
         :param outputs: A sequence of outputs you wish to send in the form
@@ -531,7 +532,6 @@ class PrivateKeyTestnet(BaseKey):
         :returns: The signed transaction as hex.
         :rtype: ``str``
         """
-
         unspents, outputs = sanitize_tx_data(
             unspents or self.unspents,
             outputs,
@@ -539,9 +539,10 @@ class PrivateKeyTestnet(BaseKey):
             leftover or self.address,
             combine=combine,
             message=message,
-            compressed=self.is_compressed()
+            compressed=self.is_compressed(),
+            custom_PUSHDATA=custom_PUSHDATA
         )
-
+        
         return create_p2pkh_transaction(self, unspents, outputs)
 
     def send(self, outputs, fee=None, leftover=None, combine=True,


### PR DESCRIPTION
# Minor modifications of bitcash allowing for the bitPUSHER module
## bitPUSHER aims to be a comprehensive solution for:
### 1) Broadcasting custom OP_RETURN PUSHDATA onto the bitcoin cash blockchain
### 2) Easy interface with popular industry standards and protocols such as:
- Tokenisation standards: e.g. SLP (Simple Ledger Protocol - see https://docs.google.com/document/d/1GcDGiVUEa87SIEjrvM9QcCINfoBw-R7EPWzNVR4M8EI);
- Standard registration of Token ID / Issuer ID
- Broadcasting the SHA256 hash of important data / contracts onto the blockchain with your preference of intellectual provider archive / industry standard protocol
- Support for a few special cases such as _memo.cash_ and _blockpress.org_ to allow easy access for beginner python developers to gain experience playing around with OP_RETURN-based apps.

## "bitPULLER" is also suggested as a complementary counterpart
- This would come in the form of an easy-to-use bitDB query API for python which would synergise well with bitPUSHER in more than just name!

### These two modules together would aim to lower barriers to entry for new developers interested in bitcoin cash and make it as easy as possible to: 
- create apps 
- interact with existing apps 
- Do powerful searches / queries of block-chain metadata with an intuitive API.

_Later I would like to package these functions into a Qt GUI for more mainstream use by tech-savvy crypto-enthusiasts._